### PR TITLE
Ubuntu 20.04 action fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 scikit-image
-agpypeline
+agpypeline==0.0.50
 


### PR DESCRIPTION
The gdal version requirement for AgPypeline has has changed and is not compatible with Ubuntu 20.04